### PR TITLE
Fix ClientSession default argument

### DIFF
--- a/apple_weatherkit/client.py
+++ b/apple_weatherkit/client.py
@@ -34,7 +34,7 @@ class WeatherKitApiClient:
         service_id: str,
         team_id: str,
         key_pem: str,
-        session: aiohttp.ClientSession = aiohttp.ClientSession(),
+        session: aiohttp.ClientSession | None,
     ) -> None:
         self._key_id = key_id
         self._service_id = service_id
@@ -96,6 +96,8 @@ class WeatherKitApiClient:
         headers: dict | None = None,
     ) -> any:
         """Get information from the API."""
+        if self._session is None:
+            self._session = aiohttp.ClientSession()
         try:
             async with async_timeout.timeout(10):
                 response = await self._session.request(


### PR DESCRIPTION
Default arguments are evaluated in the parent scope. I.e. even if `WeatherKitApiClient` is initialized with a `session`, a new `ClientSession` has already been created.

Better to move the creation into a function body and guard it by a check if `self._session` has already been set.

This would also fix a couple of DeprecationWarnings for Home Assistant.
```
venv/lib/python3.11/site-packages/apple_weatherkit/client.py:37
  /,,,/venv/lib/python3.11/site-packages/apple_weatherkit/client.py:37: DeprecationWarning: The object should be created within an async function
    session: aiohttp.ClientSession = aiohttp.ClientSession(),

venv/lib/python3.11/site-packages/aiohttp/connector.py:767
venv/lib/python3.11/site-packages/aiohttp/connector.py:767
  /,,,/venv/lib/python3.11/site-packages/aiohttp/connector.py:767: DeprecationWarning: The object should be created within an async function
    super().__init__(

venv/lib/python3.11/site-packages/aiohttp/connector.py:778
venv/lib/python3.11/site-packages/aiohttp/connector.py:778
  /,,,/venv/lib/python3.11/site-packages/aiohttp/connector.py:778: DeprecationWarning: The object should be created within an async function
    resolver = DefaultResolver(loop=self._loop)

venv/lib/python3.11/site-packages/aiohttp/cookiejar.py:67
venv/lib/python3.11/site-packages/aiohttp/cookiejar.py:67
  /,,,/venv/lib/python3.11/site-packages/aiohttp/cookiejar.py:67: DeprecationWarning: The object should be created within an async function
    super().__init__(loop=loop)
```