### PR TITLE
Misc fixes for `client.py`

### DIFF
--- a/apple_weatherkit/client.py
+++ b/apple_weatherkit/client.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-import datetime
 import json
 import socket
 from collections import OrderedDict
+from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 from urllib.parse import urlencode
 
@@ -47,18 +47,18 @@ class WeatherKitApiClient:
         lat: float,
         lon: float,
         data_sets: list[DataSetType] = [DataSetType.CURRENT_WEATHER],
-        hourly_start: datetime.datetime | None = None,
-        hourly_end: datetime.datetime | None = None,
+        hourly_start: datetime | None = None,
+        hourly_end: datetime | None = None,
         lang: str = "en-US"
     ) -> Any:
-        hourly_start = hourly_start or datetime.datetime.utcnow()
-        hourly_end = hourly_end or datetime.datetime.utcnow() + datetime.timedelta(days=1)
+        hourly_start = hourly_start or datetime.now(tz=UTC)
+        hourly_end = hourly_end or datetime.now(tz=UTC) + timedelta(days=1)
         token = self._generate_jwt()
         query = urlencode(
             OrderedDict(
                 dataSets=",".join(data_sets),
-                hourlyStart=hourly_start.isoformat() + "Z",
-                hourlyEnd=hourly_end.isoformat() + "Z",
+                hourlyStart=hourly_start.isoformat(),
+                hourlyEnd=hourly_end.isoformat(),
             )
         )
 

--- a/apple_weatherkit/client.py
+++ b/apple_weatherkit/client.py
@@ -47,10 +47,12 @@ class WeatherKitApiClient:
         lat: float,
         lon: float,
         data_sets: list[DataSetType] = [DataSetType.CURRENT_WEATHER],
-        hourly_start: datetime.datetime = datetime.datetime.utcnow(),
-        hourly_end: datetime.datetime = datetime.datetime.utcnow() + datetime.timedelta(days=1),
+        hourly_start: datetime.datetime | None = None,
+        hourly_end: datetime.datetime | None = None,
         lang: str = "en-US"
     ) -> Any:
+        hourly_start = hourly_start or datetime.datetime.utcnow()
+        hourly_end = hourly_end or datetime.datetime.utcnow() + datetime.timedelta(days=1)
         token = self._generate_jwt()
         query = urlencode(
             OrderedDict(

--- a/apple_weatherkit/client.py
+++ b/apple_weatherkit/client.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import json
 import socket
-from collections import OrderedDict
 from datetime import UTC, datetime, timedelta
 from typing import Any, Literal
 from urllib.parse import urlencode
@@ -55,11 +54,11 @@ class WeatherKitApiClient:
         hourly_end = hourly_end or datetime.now(tz=UTC) + timedelta(days=1)
         token = self._generate_jwt()
         query = urlencode(
-            OrderedDict(
-                dataSets=",".join(data_sets),
-                hourlyStart=hourly_start.isoformat(),
-                hourlyEnd=hourly_end.isoformat(),
-            )
+            {
+                "dataSets": ",".join(data_sets),
+                "hourlyStart": hourly_start.isoformat(),
+                "hourlyEnd": hourly_end.isoformat(),
+            }
         )
 
         return await self._api_wrapper(

--- a/apple_weatherkit/client.py
+++ b/apple_weatherkit/client.py
@@ -52,12 +52,17 @@ class WeatherKitApiClient:
     ) -> Any:
         hourly_start = hourly_start or datetime.now(tz=UTC)
         hourly_end = hourly_end or datetime.now(tz=UTC) + timedelta(days=1)
+        if hourly_start.tzinfo:
+            hourly_start = hourly_start.astimezone(tz=UTC).replace(tzinfo=None)
+        if hourly_end.tzinfo:
+            hourly_end = hourly_end.astimezone(tz=UTC).replace(tzinfo=None)
+
         token = self._generate_jwt()
         query = urlencode(
             {
                 "dataSets": ",".join(data_sets),
-                "hourlyStart": hourly_start.isoformat(),
-                "hourlyEnd": hourly_end.isoformat(),
+                "hourlyStart": f"{hourly_start.isoformat()}Z",
+                "hourlyEnd": f"{hourly_end.isoformat()}Z",
             }
         )
 

--- a/apple_weatherkit/client.py
+++ b/apple_weatherkit/client.py
@@ -5,7 +5,7 @@ import datetime
 import json
 import socket
 from collections import OrderedDict
-from typing import Literal
+from typing import Any, Literal
 from urllib.parse import urlencode
 
 import aiohttp
@@ -50,7 +50,7 @@ class WeatherKitApiClient:
         hourly_start: datetime.datetime = datetime.datetime.utcnow(),
         hourly_end: datetime.datetime = datetime.datetime.utcnow() + datetime.timedelta(days=1),
         lang: str = "en-US"
-    ) -> any:
+    ) -> Any:
         token = self._generate_jwt()
         query = urlencode(
             OrderedDict(
@@ -94,7 +94,7 @@ class WeatherKitApiClient:
         url: str,
         data: dict | None = None,
         headers: dict | None = None,
-    ) -> any:
+    ) -> Any:
         """Get information from the API."""
         if self._session is None:
             self._session = aiohttp.ClientSession()


### PR DESCRIPTION
- Fix typing: Replace `any` (the function) with `typing.Any`
- Remove `OrderedDict`: for newer Python (>=3.7) versions the insertion order into dicts is already kept
- Move default arguments for `hourly_start` and `hourly_end` into the function body. Otherwise they are executed when the the class is initialized. I.e. those arguments would stay the same for new method calls.
- Replace `datetime.utcnow` with the timezone aware `datetime.now(tz=UTC)`.
_`utcnow` will be deprecated with Python 3.12._

I wasn't sure about the `+ "Z"` which you added manually to the iso datetime. Could you check which format the API expects? `datetime.isoformat` would return `YYYY-MM-DDTHH:MM:SS.ffffff+HH:MM`.
https://docs.python.org/3/library/datetime.html#datetime.datetime.isoformat